### PR TITLE
Initial release

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+Please only file issues here that you believe represent actual bugs or feature requests for the JW Platform Go library.
+
+If you are having general trouble with your JW Player integration, please reach out to support using the form at https://support.jwplayer.com (preferred) or via email to support@jwplayer.com.
+
+If you are reporting a bug, please include your Go version and the version of the JW Platform Go library you're using, as well as any other details that may be helpful in reproducing the problem.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+0.1.0 (ksindi)
+--------------
+
+* Initial release

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+APPNAME = jwplatform-go
+VERSION := $(shell head CHANGELOG.md | grep -e '^[0-9]' | head -n 1 | cut -f 1 -d ' ')
+GOPATH  ?= $(curdir)/.gopath
+
+export GOPATH
+
+all: test
+
+test:
+	@echo -e '\e[01;34mRunning Go unit tests\e[0m'
+	@go test -cover
+
+release: version.go | test
+	go mod tidy
+	@echo "Releasing $(APPNAME) v$(VERSION)"
+	git tag v$(VERSION)
+	git push --tags
+
+clean:
+	@rm -rf build
+
+distclean: clean
+	@rm -rf Gopkg.lock
+
+.PHONY: clean distclean

--- a/README.md
+++ b/README.md
@@ -1,2 +1,99 @@
-# jwplatform-go
-:gopher: A Go client library for accessing JW Platform API
+# Go JW Platform
+
+Official Go client library for accessing JW Platform API.
+
+## Requirements
+
+Go 1.13+
+
+## Installation
+
+Install jwplatform-go with:
+
+```sh
+go get -u github.com/jwplayer/jwplatform-go
+```
+
+### Using Go modules
+
+``` go
+module github.com/my/package
+
+require (
+    github.com/jwplayer/jwplatform-go v0.1.0
+)
+```
+
+## Usage
+
+```go
+import (
+  "github.com/jwplayer/jwplatform-go"
+)
+
+client := jwplatform.NewClient("API_KEY", "API_SECRET")
+```
+
+### Example: Get video metadata
+
+```go
+package main
+
+import (
+  "context"
+  "fmt"
+  "log"
+  "net/http"
+  "net/url"
+  "os"
+
+  "github.com/jwplayer/jwplatform-go"
+)
+
+func main() {
+  ctx, cancel := context.WithCancel(context.Background())
+  defer cancel()
+
+  apiKey := os.Getenv("JWPLATFORM_API_KEY")
+  apiSecret := os.Getenv("JWPLATFORM_API_SECRET")
+
+  client := jwplatform.NewClient(apiKey, apiSecret)
+
+  // set URL params
+  params := url.Values{}
+  params.Set("video_key", "VIDEO_KEY")
+
+  // declare an empty interface
+  var result map[string]interface{}
+
+  _, err := client.MakeRequest(ctx, http.MethodGet, "/videos/show/", params, &result)
+
+  if err != nil {
+  	log.Fatal(err)
+  }
+
+  fmt.Println(result["status"])  // ok
+}
+```
+
+## Test
+
+The test suite needs testify's `assert` package to run:
+
+    github.com/stretchr/testify/assert
+
+Before running the tests, make sure to grab all of the package's dependencies:
+
+    go get -t -v
+
+Run all tests:
+
+    make test
+
+For any requests, bug or comments, please [open an issue][issues] or [submit a
+pull request][pulls].
+
+## License
+
+JW Platform API Go library is distributed under the
+[Apache v2.0 license](LICENSE).

--- a/client.go
+++ b/client.go
@@ -1,0 +1,129 @@
+/*
+Package jwplatform provides a client to talk to the JW Platform API,
+
+		import (
+		  "github.com/jwplayer/jwplatform-go"
+		)
+
+		client := jwplatform.NewClient("API_KEY", "API_SECRET")
+*/
+package jwplatform
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"time"
+)
+
+const (
+	APIVersion = "v1"
+	APIHost    = "api.jwplatform.com"
+	Version    = "0.1.0"
+)
+
+// Client represents the JWPlatform client object,
+type Client struct {
+	APIVersion string
+	BaseURL    *url.URL
+	UserAgent  string
+	Version    string
+
+	apiKey     string
+	apiSecret  string
+	httpClient *http.Client
+}
+
+// NewClient creates a new client object.
+func NewClient(apiKey string, apiSecret string) *Client {
+	return &Client{
+		APIVersion: APIVersion,
+		BaseURL: &url.URL{
+			Scheme: "https",
+			Host:   APIHost,
+		},
+		UserAgent: fmt.Sprintf("jwplatform-go/%s", Version),
+		Version:   Version,
+
+		apiKey:     apiKey,
+		apiSecret:  apiSecret,
+		httpClient: http.DefaultClient,
+	}
+}
+
+// generateNonce generates a random 8 digit as a string.
+func generateNonce() string {
+	rand.Seed(time.Now().UTC().UnixNano())
+	return fmt.Sprintf("%08d", rand.Intn(100000000))
+}
+
+// makeTimestamp gets the unix timestamp in seconds.
+func makeTimestamp() int64 {
+	return time.Now().UnixNano() / (int64(time.Second) / int64(time.Nanosecond))
+}
+
+// buildParams generates all parameters for api request.
+func (c *Client) buildParams(params url.Values) url.Values {
+	if params == nil {
+		params = url.Values{}
+	}
+
+	params.Set("api_nonce", generateNonce())
+	params.Set("api_key", c.apiKey)
+	params.Set("api_format", "json")
+	params.Set("api_timestamp", strconv.FormatInt(makeTimestamp(), 10))
+
+	// hash signature base string
+	sbs := params.Encode() + c.apiSecret
+	h := sha1.New()
+	h.Write([]byte(sbs))
+	sha := hex.EncodeToString(h.Sum(nil))
+
+	params.Set("api_signature", sha)
+
+	return params
+}
+
+// newRequestWithContext create a new request with signed params
+func (c *Client) newRequestWithContext(ctx context.Context, method, pathPart string, params url.Values) (*http.Request, error) {
+	rel := &url.URL{Path: path.Join(c.APIVersion, pathPart)}
+	absoluteURL := c.BaseURL.ResolveReference(rel)
+	absoluteURL.RawQuery = c.buildParams(params).Encode()
+
+	req, err := http.NewRequestWithContext(ctx, method, absoluteURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Add("User-Agent", c.UserAgent)
+
+	return req, nil
+}
+
+// do decodes response body into v
+func (c *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	err = json.NewDecoder(resp.Body).Decode(v)
+	return resp, err
+}
+
+// MakeRequest requests with api signature and decodes json result into v
+func (c *Client) MakeRequest(ctx context.Context, method, pathPart string, params url.Values, v interface{}) (*http.Response, error) {
+	req, err := c.newRequestWithContext(ctx, method, pathPart, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.do(req, &v)
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,28 @@
+package jwplatform
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_BuildParams(t *testing.T) {
+	client := NewClient("API_KEY", "API_SECRET")
+
+	// set URL params
+	params := url.Values{}
+	params.Set("video_key", "VIDEO_KEY")
+
+	rawQuery := client.buildParams(params).Encode()
+
+	m, err := url.ParseQuery(rawQuery)
+
+	assert.Nil(t, err)
+	assert.Equal(t, m["api_format"], []string{"json"})
+	assert.Equal(t, m["api_key"], []string{"API_KEY"})
+	assert.Equal(t, m["video_key"], []string{"VIDEO_KEY"})
+	assert.Contains(t, m, "api_nonce")
+	assert.Contains(t, m, "api_signature")
+	assert.Contains(t, m, "api_timestamp")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/jwplayer/jwplayer-go/v0.1.0
+
+go 1.13
+
+require github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Initial release of the Go client. This client relies on the user to pass in the endpoint path.

A follow up PR will add an `client.Upload` method to make it easy to upload videos.